### PR TITLE
Suspension des offres de recrutement

### DIFF
--- a/content/nous-rejoindre/developpeur-js-confirme.md
+++ b/content/nous-rejoindre/developpeur-js-confirme.md
@@ -6,6 +6,7 @@ readtime: 8
 location: 'Paris et/ou télétravail'
 aliases:
   - /jobs/developpeur-js-confirmé.html
+draft: true
 ---
 
 ## Missions

--- a/content/nous-rejoindre/developpeur-php-confirme.md
+++ b/content/nous-rejoindre/developpeur-php-confirme.md
@@ -6,6 +6,7 @@ readtime: 8
 location: 'Paris et/ou télétravail'
 aliases:
   - /jobs/developpeur-php-confirmé.html
+draft: true
 ---
 
 ## Missions

--- a/layouts/nous-rejoindre/list.html
+++ b/layouts/nous-rejoindre/list.html
@@ -16,7 +16,7 @@
 
     </div>
 
-    {{ range .Paginator.Pages}}
+    {{ range where .Paginator.Pages "Draft" false }}
 
     <section>
         <div class="content">
@@ -41,6 +41,15 @@
             </a>
         </div>
     </section>
+
+    {{ else }}
+
+    <hr />
+
+    <div class="article-content">
+        <p>Nous ne cherchons pas à recruter pour le moment.</p>
+        <p>Néanmoins, n'hésitez pas à nous écrire à equipe[@]fairness.coop pour déposer une candidature spontanée.</p>
+    </div>
 
     {{end}}
 

--- a/layouts/nous-rejoindre/list.html
+++ b/layouts/nous-rejoindre/list.html
@@ -47,7 +47,7 @@
     <hr />
 
     <div class="article-content">
-        <p>Nous ne cherchons pas à recruter pour le moment.</p>
+        <p>Nous ne recrutons pas pour le moment.</p>
         <p>Néanmoins, n'hésitez pas à nous écrire à equipe[@]fairness.coop pour déposer une candidature spontanée.</p>
     </div>
 


### PR DESCRIPTION
Puisqu'on ne cherche pas à recruter en ce moment, cette PR passe les deux offres en DRAFT.

Un avis sur le phrasé du message de remplacement ?

> Nous ne cherchons pas à recruter pour le moment.
>
> Néanmoins, n'hésitez pas à nous écrire à equipe[@]fairness.coop pour déposer une candidature spontanée.

![Screenshot 2022-10-24 at 12-33-14 Nous rejoindre](https://user-images.githubusercontent.com/15911462/197506877-6cc3b367-aecc-4125-b126-1fc0b1216ef8.png) (70kB)
