### PR TITLE
Correction d'un bug d'affichage sur la liste du blog

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -9,7 +9,11 @@
         <div class="content">
             <h2 id="{{ .File.TranslationBaseName }}"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
             <p>
-                {{ .Description }}
+                {{ if (gt (len .Description) 80) }}
+                    {{ truncate 80 .Description }}
+                {{ else }}
+                    {{ .Description }}
+                {{ end }}
             </p>
             <p class="indicators">
                 <img src="{{ "image/date.svg" | relURL }}" alt=""> {{ .Date.Format "02/01/2006"  }}


### PR DESCRIPTION
Les blocs débordent car le texte est trop volumineux.
Cette PR corrige ce bug d'affichage en coupant la description au delà de 80 caractères.

Avant : 
![image](https://user-images.githubusercontent.com/44842796/203814431-dca2280f-ab74-4d13-9811-894663090fdc.png)

Après : 
![image](https://user-images.githubusercontent.com/44842796/203814568-99897674-2573-4b49-9482-238b69b8e6d0.png)
